### PR TITLE
Hotfix 1.0.5: Put error output behind CO_MIX_DEBUG flag

### DIFF
--- a/lib/co_mix.ex
+++ b/lib/co_mix.ex
@@ -35,7 +35,9 @@ defmodule CoMix do
         raise "Closest tag #{inspect(tag)} doesn't start with v?! (not version tag?)"
 
       {:error, error} ->
-        IO.puts("Could not get version. Error: #{inspect(error)}")
+        if System.get_env("CO_MIX_DEBUG") do
+          IO.puts("Could not get version. Error: #{inspect(error)}")
+        end
         @default_version
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule CoMix.MixProject do
   def project do
     [
       app: :co_mix,
-      version: "1.0.4",
+      version: "1.0.5",
       elixir: "~> 1.12",
       package: package(),
       description: "Common mix.exs code that all projects can benefit from",


### PR DESCRIPTION
This should fix dependabot incorrectly processing this output

This may not be the only fix needed to make dependabot happy, but this gets us a step forward in the process.